### PR TITLE
Switch the errors from being strings to being structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ import (
 	"image/png"
 	"os"
 
-	_ "github.com/mdouchement/dng"
+	_ "github.com/eberle1080/dng"
 )
 
 var (


### PR DESCRIPTION
Newer version of go change how `%s` is interpolated in format strings. The current implementation assumes that `%s` will resolve to the literal string value, when in fact it resolves to the error type and thus recurses infinitely.

Treating strings as errors is the root of the problem. This PR changes the strings to be structs, and removes the ambiguity.

Here's a small portion of the stack trace to demonstrate the problem. Note this is using golang v 1.20.6

```github.com/mdouchement/dng.UnsupportedError.Error(...)
        /Users/chris/go/pkg/mod/github.com/mdouchement/dng@v0.0.0-20170415183926-292bb2b0015a/reader.go:45
github.com/mdouchement/dng.(*UnsupportedError).Error(0xc02e07dca0?)
        <autogenerated>:1 +0x69 fp=0xc02e07dc78 sp=0xc02e07dc30 pc=0x1fb81c9
fmt.(*pp).handleMethods(0xc01679d860, 0xf63c0108?)
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:667 +0x1bf fp=0xc02e07dec8 sp=0xc02e07dc78 pc=0xe080df
fmt.(*pp).printArg(0xc01679d860, {0x2601cc0?, 0xc01678ee70}, 0x73)
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:756 +0x69b fp=0xc02e07df68 sp=0xc02e07dec8 pc=0xe08d7b
fmt.(*pp).doPrintf(0xc01679d860, {0x2a025b9, 0x1c}, {0xc02e07e0e0?, 0x1, 0x1})
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:1077 +0x387 fp=0xc02e07e060 sp=0xc02e07df68 pc=0xe0b8c7
fmt.Sprintf({0x2a025b9, 0x1c}, {0xc02e07e0e0, 0x1, 0x1})
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:239 +0x59 fp=0xc02e07e0b8 sp=0xc02e07e060 pc=0xe05939
github.com/mdouchement/dng.UnsupportedError.Error(...)
        /Users/chris/go/pkg/mod/github.com/mdouchement/dng@v0.0.0-20170415183926-292bb2b0015a/reader.go:45
github.com/mdouchement/dng.(*UnsupportedError).Error(0xc02e07e128?)
        <autogenerated>:1 +0x69 fp=0xc02e07e100 sp=0xc02e07e0b8 pc=0x1fb81c9
fmt.(*pp).handleMethods(0xc01679d790, 0xf63c0108?)
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:667 +0x1bf fp=0xc02e07e350 sp=0xc02e07e100 pc=0xe080df
fmt.(*pp).printArg(0xc01679d790, {0x2601cc0?, 0xc01678ee60}, 0x73)
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:756 +0x69b fp=0xc02e07e3f0 sp=0xc02e07e350 pc=0xe08d7b
fmt.(*pp).doPrintf(0xc01679d790, {0x2a025b9, 0x1c}, {0xc02e07e568?, 0x1, 0x1})
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:1077 +0x387 fp=0xc02e07e4e8 sp=0xc02e07e3f0 pc=0xe0b8c7
fmt.Sprintf({0x2a025b9, 0x1c}, {0xc02e07e568, 0x1, 0x1})
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:239 +0x59 fp=0xc02e07e540 sp=0xc02e07e4e8 pc=0xe05939
github.com/mdouchement/dng.UnsupportedError.Error(...)
        /Users/chris/go/pkg/mod/github.com/mdouchement/dng@v0.0.0-20170415183926-292bb2b0015a/reader.go:45
github.com/mdouchement/dng.(*UnsupportedError).Error(0xc02e07e5b0?)
        <autogenerated>:1 +0x69 fp=0xc02e07e588 sp=0xc02e07e540 pc=0x1fb81c9
fmt.(*pp).handleMethods(0xc01679d6c0, 0xf63c0108?)
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:667 +0x1bf fp=0xc02e07e7d8 sp=0xc02e07e588 pc=0xe080df
fmt.(*pp).printArg(0xc01679d6c0, {0x2601cc0?, 0xc01678ee50}, 0x73)
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:756 +0x69b fp=0xc02e07e878 sp=0xc02e07e7d8 pc=0xe08d7b
fmt.(*pp).doPrintf(0xc01679d6c0, {0x2a025b9, 0x1c}, {0xc02e07e9f0?, 0x1, 0x1})
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:1077 +0x387 fp=0xc02e07e970 sp=0xc02e07e878 pc=0xe0b8c7
fmt.Sprintf({0x2a025b9, 0x1c}, {0xc02e07e9f0, 0x1, 0x1})
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:239 +0x59 fp=0xc02e07e9c8 sp=0xc02e07e970 pc=0xe05939
github.com/mdouchement/dng.UnsupportedError.Error(...)
        /Users/chris/go/pkg/mod/github.com/mdouchement/dng@v0.0.0-20170415183926-292bb2b0015a/reader.go:45
github.com/mdouchement/dng.(*UnsupportedError).Error(0xc02e07ea38?)
        <autogenerated>:1 +0x69 fp=0xc02e07ea10 sp=0xc02e07e9c8 pc=0x1fb81c9
fmt.(*pp).handleMethods(0xc01679d5f0, 0xf63c0108?)
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:667 +0x1bf fp=0xc02e07ec60 sp=0xc02e07ea10 pc=0xe080df
fmt.(*pp).printArg(0xc01679d5f0, {0x2601cc0?, 0xc01678ee40}, 0x73)
        /opt/homebrew/Cellar/go/1.20.6/libexec/src/fmt/print.go:756 +0x69b fp=0xc02e07ed00 sp=0xc02e07ec60 pc=0xe08d7b
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /Users/chris/go/pkg/mod/google.golang.org/grpc@v1.55.0/server.go:957 +0x18c
```